### PR TITLE
Migrate hardcoded data to Payload

### DIFF
--- a/app/(site)/(aefeup)/about/AvatarLineup.tsx
+++ b/app/(site)/(aefeup)/about/AvatarLineup.tsx
@@ -17,6 +17,11 @@ const AvatarLineup = ({ sections }: Props) => {
   const main_board = sections.find((e) => e.type === 'presidencia');
   const otherSections = sections.filter((e) => e.type === 'mesa_da_assembleia_geral' || e.type === 'conselho_fiscal');
 
+  if (!main_board) return null;
+
+  const firstRowMembers = main_board.members.slice(0, 3);
+  const secondRowMembers = main_board.members.slice(3);
+
   return (
     <motion.div
       initial="hidden"
@@ -31,8 +36,19 @@ const AvatarLineup = ({ sections }: Props) => {
       {main_board && (
         <div className="flex flex-col items-center mt-5 gap-7 ">
           <h3 className="text-black dark:text-white text-3xl font-medium text-center">Presidência</h3>
-          <div className="flex justify-center flex-wrap gap-5 ">
-            {main_board && main_board.members.map((person,key) => (<Avatar key={key} person={person as Person} />))}
+          <div className="flex flex-col gap-5 w-full">
+            <div className="flex justify-center flex-wrap gap-5">
+              {firstRowMembers.map((person, key) => (
+                <Avatar key={key} person={person as Person} />
+              ))}
+            </div>
+            {secondRowMembers.length > 0 && (
+              <div className="flex justify-center flex-wrap gap-5">
+                {secondRowMembers.map((person, key) => (
+                  <Avatar key={key} person={person as Person} />
+                ))}
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/app/(site)/sport/history/page.tsx
+++ b/app/(site)/sport/history/page.tsx
@@ -1,7 +1,9 @@
 import { Metadata } from "next";
 import { Timeline } from "@/components/ui/timeline";
 import SectionHeader from "@/components/Common/SectionHeader";
-import { historyTimelineData } from "./historyTimelineData";
+import { getPayload } from "payload";
+import config from "payload.config";
+import SportHistoryTable from "@/components/SportHistoryTable";
 import Text from "@/components/Text";
 import historyTextSections from "./historyTextSection";
 
@@ -10,7 +12,23 @@ export const metadata: Metadata = {
   description: "Descobre a história e os troféus da AEFEUP",
 };
 
-const HistoryPage = () => {
+const HistoryPage = async () => {
+  const payload = await getPayload({ config });
+  const trophiesData = await payload.find({ collection: "trophies"});
+
+  const historyTimelineData = trophiesData.docs.map((yearData: any) => ({
+    title: yearData.year,
+    content: (
+      <SportHistoryTable
+        data={yearData.trophies.map((trophy: any) => ({
+          label: trophy.competition?.name || "",
+          value: trophy.sportsTeam?.sport_name || "",
+          classification: trophy.standing?.name || "",
+        }))}
+      />
+    ),
+  }));
+
   return (
     <section className="pt-20 pb-12 lg:pt-25 xl:pt-30">
       <div className="mx-auto max-w-c-1315 px-4 md:px-8 xl:px-0">

--- a/app/(site)/student/opportunities/client.tsx
+++ b/app/(site)/student/opportunities/client.tsx
@@ -1,73 +1,57 @@
 "use client"
 
 import SectionHeader from "@/components/Common/SectionHeader"
-import volunteeringData from "./volunteeringData"
-import workshopData from "./workshopData"
 import LearnMore from "@/components/LearnMore"
+import { HandHeart, BookOpenText, HeartHandshake, Heart, Users, GraduationCap, Globe, Sheet, Star, Briefcase, HelpingHand } from "lucide-react";
 
-const OpportunitiesClientPage = () => {
+const iconMap: Record<string, React.ReactNode> = {
+  HandHeart: <HandHeart />,
+  BookOpenText: <BookOpenText />,
+  HeartHandshake: <HeartHandshake />,
+  Heart: <Heart />,
+  Users: <Users />,
+  GraduationCap: <GraduationCap />,
+  Globe: <Globe />,
+  Sheet: <Sheet />,
+  Star: <Star />,
+  Briefcase: <Briefcase />,
+  HelpingHand: <HelpingHand />,
+};
+
+const OpportunitiesClientPage = ({ opportunities }: { opportunities: any }) => {
    return (<>
-      {/* <!-- VOLUNTARIADO --> */}
-      <section className="overflow-hidden pt-25 lg:pb-15 xl:pb-20">
-         <div className="mx-auto max-w-c-1315 px-4 md:px-8 xl:px-0">
-            {/* <!-- Section Title Start --> */}
-            <div className="animate_top mx-auto text-center">
-               <SectionHeader
-                  title="Voluntariado"
-                  description="Ações de interesse social e comunitário realizadas de forma desinteressada que desenvolvem competências pessoais e sociais e promovem a responsabilidade, ética e compromisso social."
-               />
-            </div>
-            {/* <!-- Section Title End --> */}
-            <div className="py-20">
+      {opportunities?.types?.map((type: any, idx: number) => (
+         <section key={idx} className="overflow-hidden pt-25 lg:pb-15 xl:pb-20">
+            <div className="mx-auto max-w-c-1315 px-4 md:px-8 xl:px-0">
+               {/* <!-- Section Title Start --> */}
+               <div className="animate_top mx-auto text-center">
+                  <SectionHeader
+                     title={type.title}
+                     description={type.description}
+                  />
+               </div>
+               {/* <!-- Section Title End --> */}
+               <div className="py-20">
 
-               <div className="flex flex-wrap justify-center gap-7.5 lg:flex-nowrap xl:gap-12.5">
-                  {/* <!-- Features item Start --> */}
-                  {volunteeringData.map((feature) => (
-                     <LearnMore
-                        key={feature.id}
-                        icon={feature.icon}
-                        title={feature.title}
-                        description={feature.description}
-                        details={feature.details}
-                        href={feature.href}
-                     />
-                  ))}
+                  <div className="flex flex-wrap justify-center gap-7.5 lg:flex-nowrap xl:gap-12.5">
+                     {/* <!-- Features item Start --> */}
+                     {type.opportunities?.map((feature: any, i: number) => (
+                        <LearnMore
+                           key={i}
+                           icon={iconMap[feature.icon]}
+                           title={feature.title}
+                           description={feature.description}
+                           details={feature.details?.map((d: any) => d.detail)}
+                           href={feature.href}
+                        />
+                     ))}
 
-                  {/* <!-- Features item End --> */}
+                     {/* <!-- Features item End --> */}
+                  </div>
                </div>
             </div>
-         </div>
-      </section>
-
-      <section className="overflow-hidden lg:pb-25 xl:pb-30">
-         <div className="mx-auto max-w-c-1315 px-4 md:px-8 xl:px-0">
-            {/* <!-- Section Title Start --> */}
-            <div className="animate_top mx-auto text-center">
-               <SectionHeader
-                     title="Formações"
-               />
-            </div>
-            {/* <!-- Section Title End --> */}
-            <div className="py-20 ">
-
-               <div className="flex flex-wrap justify-center gap-7.5 lg:flex-nowrap xl:gap-12.5">
-                  {/* <!-- Features item Start --> */}
-                  {workshopData.map((feature) => (
-                     <LearnMore
-                        key={feature.id}
-                        icon={feature.icon}
-                        title={feature.title}
-                        description={feature.description}
-                        details={feature.details}
-                        href={feature.href}
-                     />
-                  ))}
-
-                  {/* <!-- Features item End --> */}
-               </div>
-            </div>
-         </div>
-      </section>
+         </section>
+      ))}
    </>)
 }
 

--- a/app/(site)/student/opportunities/page.tsx
+++ b/app/(site)/student/opportunities/page.tsx
@@ -1,14 +1,29 @@
 import { Metadata } from "next";
 import OpportunitiesClientPage from './client';
+import config from "payload.config";
+import { getPayload } from "payload";
 
 export const metadata: Metadata = {
     title: "Oportunidades",
     description: "Voluntariado e Formações – AEFEUP: Ações Sociais, Desenvolvimento Pessoal e Cursos Certificados.",
 };
 
+async function getOpportunities() {
+  if (process.env.IS_BUILD) {
+    return null;
+  }
+  const payload = await getPayload({ config });
+  const opportunities = (await payload.find({
+    collection: "opportunities",
+    limit: 1,
+  })).docs[0];
+  return opportunities;
+}
+
 const OpportunitiesPage = async () => {
+    const opportunities = await getOpportunities();
     return (
-        <OpportunitiesClientPage />
+        <OpportunitiesClientPage opportunities={opportunities} />
     );
 }
 

--- a/app/(site)/student/welcome/client.tsx
+++ b/app/(site)/student/welcome/client.tsx
@@ -7,12 +7,23 @@ import { sectionsData } from "./sectionsData";
 
 interface Props {
   videos: Video[];
+  mentoringLinks: { url: string; title: string }[];
 }
 
-const WelcomeClientPage = ({ videos }: Props) => {
+const WelcomeClientPage = ({ videos, mentoringLinks }: Props) => {
+  const sections = sectionsData.map((section) => {
+    if (section.id === 3) {
+      return {
+        ...section,
+        buttons: mentoringLinks.map((link) => ({ url: link.url, label: link.title })),
+      };
+    }
+    return section;
+  });
+
   return (
     <>
-      {sectionsData.map((section) => (
+      {sections.map((section) => (
         <section
           key={section.id}
           className={`overflow-hidden pb-20 ${section.id === 1 ? 'pt-25' : ''} lg:pb-25 xl:pb-30`}
@@ -24,11 +35,9 @@ const WelcomeClientPage = ({ videos }: Props) => {
               />
             </div>
           </div>
-            {section.id === 2 && videos.length === 0 && (
-              <Text sections={[{ ...section, title: undefined }]} />
-            )}
-            {section.id !== 2 && <Text sections={[{ ...section, title: undefined }]} />}
-            {section.id === 2 && (
+          {section.id === 2 && videos.length === 0 && <Text sections={[{ ...section, title: undefined }]} />}
+          {section.id !== 2 && <Text sections={[{ ...section, title: undefined }]} />}
+          {section.id === 2 && (
             <div className="flex gap-5 justify-center mt-10">
               {/* TODO: Add animation to delay in each animation */}
               {videos.map((video) => (

--- a/app/(site)/student/welcome/page.tsx
+++ b/app/(site)/student/welcome/page.tsx
@@ -26,10 +26,23 @@ async function getVideos() {
   return videos
 }
 
-const WelcomePage = async () => {
-  const videos = await getVideos()
+async function getMentoringLinks() {
+  if (process.env.IS_BUILD) {
+    console.log('skipping getMentoringLinks DB call during build')
+    return []
+  }
+  const payload = await getPayload({ config });
+  const links = (await payload.find({
+    collection: "mentoringLinks",
+  })).docs;
+  return links;
+}
 
-  return <WelcomeClientPage videos={videos} />
+const WelcomePage = async () => {
+  const videos = await getVideos();
+  const mentoringLinks = await getMentoringLinks();
+
+  return <WelcomeClientPage videos={videos} mentoringLinks={mentoringLinks} />
 };
 
 export default WelcomePage;

--- a/app/(site)/student/welcome/sectionsData.tsx
+++ b/app/(site)/student/welcome/sectionsData.tsx
@@ -56,16 +56,6 @@ export const sectionsData : TextSection[] = [
           </p>
         </>
       )],
-      buttons: [
-        {
-          url: "https://www.up.pt/mentoriaup/inscricoes-para-mentores-as-u-porto-2022-2023/",
-          label: "Candidaturas Mentor",
-        },
-        {
-          url: "https://docs.google.com/forms/d/e/1FAIpQLSebJ9eq6allh6dUumsAxKzJM2Yt93kTXNIRjJ-SGhpc-tGo4g/viewform",
-          label: "Candidaturas Mentorado",
-        },
-      ],
     },
     {
         id: 4,
@@ -111,4 +101,3 @@ export const sectionsData : TextSection[] = [
         )],
       },
   ];
-  

--- a/app/(site)/student/welcome/sectionsData.tsx
+++ b/app/(site)/student/welcome/sectionsData.tsx
@@ -3,7 +3,7 @@ import { TextSection } from "@/types/textSection";
 export const sectionsData : TextSection[] = [
     {
       id: 1,
-      title: "Bem Vindo à FEUP",
+      title: "Bem-vindo à FEUP",
 
       text: [(
         <>

--- a/collections/Competitions.ts
+++ b/collections/Competitions.ts
@@ -1,0 +1,26 @@
+import type { CollectionConfig } from 'payload'
+
+export const Competitions: CollectionConfig = {
+  slug: 'competitions',
+  labels: {
+    singular: 'Competição',
+    plural: 'Competições',
+  },
+  admin: {
+    useAsTitle: 'name',
+    group: "Desporto",
+  },
+  fields: [
+    {
+      name: 'name',
+      label: 'Nome',
+      type: 'text',
+      required: true,
+      admin: {
+        placeholder: 'Ex: Supertaça, Taça CAP, ...'
+      },
+    },
+  ],
+};
+
+export default Competitions

--- a/collections/MentoringLinks.ts
+++ b/collections/MentoringLinks.ts
@@ -1,0 +1,44 @@
+import { isStaff } from '@/lib/utils';
+import type { CollectionConfig } from 'payload';
+
+export const MentoringLinks: CollectionConfig = {
+  slug: 'mentoringLinks',
+  labels: {
+    singular: 'Link Mentoria',
+    plural: 'Links Mentoria',
+  },
+  defaultSort: 'order',
+  admin: {
+    useAsTitle: 'title',
+    group: 'Estudante',
+  },
+  access: {
+    read: isStaff,
+    create: isStaff,
+    update: isStaff,
+    delete: isStaff,
+  },
+  fields: [
+    {
+      name: 'title',
+      label: 'Título',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'url',
+      label: 'URL',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'order',
+      label: 'Order',
+      type: 'number',
+      required: false,
+      admin: {
+        position: 'sidebar',
+      },
+    }
+  ],
+};

--- a/collections/Opportunities.ts
+++ b/collections/Opportunities.ts
@@ -1,0 +1,97 @@
+import { isStaff } from '@/lib/utils';
+import type { CollectionConfig } from 'payload';
+
+export const Opportunities: CollectionConfig = {
+  slug: 'opportunities',
+  labels: {
+    singular: 'Oportunidade',
+    plural: 'Oportunidades',
+  },
+  admin: {
+    useAsTitle: 'title',
+    group: 'Estudante',
+  },
+  access: {
+    read: isStaff,
+    create: isStaff,
+    update: isStaff,
+    delete: isStaff,
+  },
+  fields: [
+    {
+      name: 'types',
+      label: 'Tipos de Oportunidade',
+      type: 'array',
+      fields: [
+        {
+          name: 'title',
+          label: 'Título do Tipo',
+          type: 'text',
+          required: true,
+        },
+        {
+          name: 'description',
+          label: 'Descrição do Tipo',
+          type: 'textarea',
+        },
+        {
+          name: 'opportunities',
+          label: 'Oportunidades',
+          type: 'array',
+          fields: [
+            {
+              name: 'icon',
+              label: 'Ícone',
+              type: 'select',
+              options: [
+                { label: 'HandHeart', value: 'HandHeart' },
+                { label: 'BookOpenText', value: 'BookOpenText' },
+                { label: 'HeartHandshake', value: 'HeartHandshake' },
+                { label: 'Heart', value: 'Heart' },
+                { label: 'Users', value: 'Users' },
+                { label: 'GraduationCap', value: 'GraduationCap' },
+                { label: 'Globe', value: 'Globe' },
+                { label: 'Sheet', value: 'Sheet' },
+                { label: 'Star', value: 'Star' },
+                { label: 'Briefcase', value: 'Briefcase' },
+                { label: 'HelpingHand', value: 'HelpingHand' },
+              ],
+              required: true,
+            },
+            {
+              name: 'title',
+              label: 'Título',
+              type: 'text',
+              required: true,
+            },
+            {
+              name: 'description',
+              label: 'Descrição',
+              type: 'textarea',
+              required: true,
+            },
+            {
+              name: 'href',
+              label: 'URL',
+              type: 'text',
+            },
+            {
+              name: 'details',
+              label: 'Detalhes',
+              type: 'array',
+              fields: [
+                {
+                  name: 'detail',
+                  label: 'Detalhe',
+                  type: 'text',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export default Opportunities;

--- a/collections/SportsTeam.ts
+++ b/collections/SportsTeam.ts
@@ -34,6 +34,16 @@ export const SportsTeam: CollectionConfig = {
             type: 'number',
         },
         {
+            name: 'showOnTeamsPage',
+            label: 'Mostrar na página das equipas',
+            type: 'checkbox',
+            required: true,
+            defaultValue: true,
+            admin: {
+                description: 'Marcar se esta seleção deve aparecer na página das equipas ativas.',
+            },
+        },
+        {
             name: 'coach',
             label: "Treinador",
             type: 'relationship',
@@ -101,7 +111,6 @@ export const SportsTeam: CollectionConfig = {
             label: 'Imagem de fundo',
             type: 'upload',
             relationTo: 'media',
-            required: true,
         },
     ],
 };

--- a/collections/Standings.ts
+++ b/collections/Standings.ts
@@ -1,0 +1,26 @@
+import type { CollectionConfig } from 'payload'
+
+export const Standings: CollectionConfig = {
+  slug: 'standings',
+  labels: {
+    singular: 'Classificação',
+    plural: 'Classificações',
+  },
+  admin: {
+    useAsTitle: 'name',
+    group: "Desporto",
+  },
+  fields: [
+    {
+      name: 'name',
+      label: 'Nome',
+      type: 'text',
+      required: true,
+      admin: {
+        placeholder: 'Ex: Vencedor, 2º Lugar, 3º Lugar, ...'
+      },
+    },
+  ],
+};
+
+export default Standings

--- a/collections/Trophies.ts
+++ b/collections/Trophies.ts
@@ -1,0 +1,61 @@
+import { isStaff } from '@/lib/utils';
+import type { CollectionConfig } from 'payload'
+
+export const Trophies: CollectionConfig = {
+  slug: 'trophies',
+  labels: {
+    singular: 'Troféu',
+    plural: 'Troféus',
+  },
+  admin: {
+    useAsTitle: 'year',
+    group: "Desporto",
+  },
+  access: {
+          read: isStaff,
+          create: isStaff,
+          update: isStaff,
+          delete: isStaff,
+  },
+  fields: [
+    {
+      name: 'year',
+      label: 'Ano',
+      type: 'text',
+      required: true,
+      admin: {
+        placeholder: '2023/2024'
+      },
+    },
+    {
+      name: 'trophies',
+      label: 'Troféus do Ano',
+      type: 'array',
+      fields: [
+        {
+          name: 'competition',
+          label: 'Competição',
+          type: 'relationship',
+          relationTo: 'competitions',
+          required: true,
+        },
+        {
+          name: 'sportsTeam',
+          label: 'Seleção',
+          type: 'relationship',
+          relationTo: 'sportsTeam',
+          required: true,
+        },
+        {
+          name: 'standing',
+          label: 'Classificação',
+          type: 'relationship',
+          relationTo: 'standings',
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+export default Trophies;

--- a/components/Header/menuData.tsx
+++ b/components/Header/menuData.tsx
@@ -47,10 +47,10 @@ const menuData: Menu[] = [
       //   title: "Bem-vindo à FEUP",
       //   path: "welcome"
       // },
-      // {
-      //   title: "Guia do Estudante",
-      //   path: "guide"
-      // },
+      {
+        title: "Guia do Estudante",
+        path: "guide"
+      },
       {
         title: "Espaços",
         path: "spaces"

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -37,6 +37,7 @@ export interface Config {
     trophies: Trophy;
     competitions: Competition;
     standings: Standing;
+    mentoringLinks: MentoringLink;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
@@ -523,6 +524,18 @@ export interface Competition {
 export interface Standing {
   id: number;
   name: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "mentoringLinks".
+ */
+export interface MentoringLink {
+  id: number;
+  title: string;
+  url: string;
+  order?: number | null;
   updatedAt: string;
   createdAt: string;
 }

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -34,6 +34,9 @@ export interface Config {
     place: Place;
     testimonial: Testimonial;
     feedbacklinks: Feedbacklink;
+    trophies: Trophy;
+    competitions: Competition;
+    standings: Standing;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
@@ -159,6 +162,7 @@ export interface SportsTeam {
   id: number;
   sport_name: string;
   fap_id?: number | null;
+  showOnTeamsPage: boolean;
   coach?: (number | null) | Person;
   workouts?:
     | {
@@ -210,7 +214,7 @@ export interface SportsTeam {
         id?: string | null;
       }[]
     | null;
-  backgroundImage: number | Media;
+  backgroundImage?: number | Media | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -481,6 +485,44 @@ export interface Feedbacklink {
   id: number;
   name: string;
   link: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "trophies".
+ */
+export interface Trophy {
+  id: number;
+  year: string;
+  trophies?:
+    | {
+        competition: number | Competition;
+        sportsTeam: number | SportsTeam;
+        standing: number | Standing;
+        id?: string | null;
+      }[]
+    | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "competitions".
+ */
+export interface Competition {
+  id: number;
+  name: string;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "standings".
+ */
+export interface Standing {
+  id: number;
+  name: string;
   updatedAt: string;
   createdAt: string;
 }

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -38,6 +38,7 @@ export interface Config {
     competitions: Competition;
     standings: Standing;
     mentoringLinks: MentoringLink;
+    opportunities: Opportunity;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
@@ -536,6 +537,48 @@ export interface MentoringLink {
   title: string;
   url: string;
   order?: number | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "opportunities".
+ */
+export interface Opportunity {
+  id: number;
+  types?:
+    | {
+        title: string;
+        description?: string | null;
+        opportunities?:
+          | {
+              icon:
+                | 'HandHeart'
+                | 'BookOpenText'
+                | 'HeartHandshake'
+                | 'Heart'
+                | 'Users'
+                | 'GraduationCap'
+                | 'Globe'
+                | 'Sheet'
+                | 'Star'
+                | 'Briefcase'
+                | 'HelpingHand';
+              title: string;
+              description: string;
+              href?: string | null;
+              details?:
+                | {
+                    detail?: string | null;
+                    id?: string | null;
+                  }[]
+                | null;
+              id?: string | null;
+            }[]
+          | null;
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
 }

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -34,6 +34,7 @@ import { FeedbackLinks } from "./collections/FeedbackLinks";
 import { Trophies } from "./collections/Trophies";
 import { Competitions } from "./collections/Competitions";
 import { Standings } from "./collections/Standings";
+import { MentoringLinks } from "./collections/MentoringLinks";
 
 import { en } from "@payloadcms/translations/languages/en";
 import { pt } from "@payloadcms/translations/languages/pt";
@@ -73,6 +74,7 @@ export default buildConfig({
     Trophies,
     Competitions,
     Standings,
+    MentoringLinks,
   ],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || "",

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -31,6 +31,9 @@ import { Faq } from "./collections/Faq";
 import { Place } from "./collections/Place";
 import { Testimonal } from "./collections/Testimonial";
 import { FeedbackLinks } from "./collections/FeedbackLinks";
+import { Trophies } from "./collections/Trophies";
+import { Competitions } from "./collections/Competitions";
+import { Standings } from "./collections/Standings";
 
 import { en } from "@payloadcms/translations/languages/en";
 import { pt } from "@payloadcms/translations/languages/pt";
@@ -67,6 +70,9 @@ export default buildConfig({
     Place,
     Testimonal,
     FeedbackLinks,
+    Trophies,
+    Competitions,
+    Standings,
   ],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || "",

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -35,6 +35,7 @@ import { Trophies } from "./collections/Trophies";
 import { Competitions } from "./collections/Competitions";
 import { Standings } from "./collections/Standings";
 import { MentoringLinks } from "./collections/MentoringLinks";
+import { Opportunities } from "./collections/Opportunities";
 
 import { en } from "@payloadcms/translations/languages/en";
 import { pt } from "@payloadcms/translations/languages/pt";
@@ -75,6 +76,7 @@ export default buildConfig({
     Competitions,
     Standings,
     MentoringLinks,
+    Opportunities,
   ],
   editor: lexicalEditor(),
   secret: process.env.PAYLOAD_SECRET || "",


### PR DESCRIPTION
Moved hardcoded opportunities, mentoring links, and trophies data to Payload, updated Guia do Estudante visibility, and adjusted main board member display.